### PR TITLE
Feat: 선호 설정 등록 API

### DIFF
--- a/src/main/java/com/nurigil/nurigil/NurigilApplication.java
+++ b/src/main/java/com/nurigil/nurigil/NurigilApplication.java
@@ -2,8 +2,10 @@ package com.nurigil.nurigil;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class NurigilApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/nurigil/nurigil/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/nurigil/nurigil/global/apiPayload/code/status/ErrorStatus.java
@@ -34,29 +34,25 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_REQUEST_INFO(HttpStatus.UNAUTHORIZED, "AUTH_007", "카카오 정보 불러오기에 실패하였습니다."),
     AUTH_INVALID_CODE(HttpStatus.UNAUTHORIZED, "AUTH_008", "코드가 유효하지 않습니다."),
 
-    // User 관련
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "존재하지 않는 사용자입니다."),
-    USER_EXISTS(HttpStatus.BAD_REQUEST, "USER_002", "이미 존재하는 아이디입니다."),
-    USER_DELETE_FAILED(HttpStatus.NOT_FOUND, "USER_003", "회원 탈퇴에 실패했습니다."),
+    // Member 관련
+    MEMBER_ID_NULL(HttpStatus.BAD_REQUEST, "MEMBER_4001", "사용자 아이디는 필수 입니다."),
+    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER_4002", "사용자가 없습니다."),
+    MEMBER_NAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER_4003", "이름입력은 필수 입니다."),
+    MEMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "MEMBER_4091", "이미 존재하는 유저입니다."),
+    MEMBER_ADMIN_UNAUTHORIZED(HttpStatus.BAD_REQUEST, "MEMBER_4004", "관리자 권한이 없습니다."),
+    MEMBER_LOGIN_FAIL(HttpStatus.BAD_REQUEST, "MEMBER_4005", "아이디나 비밀번호가 올바르지 않습니다."),
+    MEMBER_WRONG_EMAIL(HttpStatus.BAD_REQUEST, "MEMBER_4006", "이메일 형식이 올바르지 않습니다."),
+    MEMBER_WRONG_PASSWORD(HttpStatus.BAD_REQUEST, "MEMBER_4007", "비밀번호 형식이 올바르지 않습니다."),
+    MEMBER_EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "MEMBER_4092", "이미 가입된 이메일입니다."),
+    MEMBER_NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "MEMBER_4093", "이미 존재하는 닉네임입니다."),
+
+    // MemberPreference 관련
+    MEMBER_PREFERENCE_ALREADY_EXISTS(HttpStatus.CONFLICT, "MEMBERPREFERENCE_4091", "이미 선호 설정이 존재합니다."),
 
     //Search 관련
     SEARCH_CONDITION_INVALID(HttpStatus.BAD_REQUEST, "SEARCH_001", "검색 조건이 하나라도 존재해야 합니다."),
     RECREATION_NOT_FOUND(HttpStatus.NOT_FOUND, "SEARCH_001", "검색 결과가 존재하지 않습니다."),
 
-    //Place 관련
-    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "PLACE_001", "필터에 해당하는 카테고리가 없습니다. 실내/야외 중 선택해주세요."),
-    MOOD_NOT_FOUND(HttpStatus.NOT_FOUND, "PLACE_002", "필터에 해당하는 분위기가 없습니다. 편안한/신나는/차분한/즐거운/아늑한/재미있는 중에 선택해주세요."),
-    SIZE_NOT_FOUND(HttpStatus.NOT_FOUND, "PLACE_003", "필터에 해당하는 공간크기가 없습니다. 부족/보통/넉넉 중에 선택해주세요."),
-    OUTLET_NOT_FOUND(HttpStatus.NOT_FOUND, "PLACE_004", "필터에 해당하는 콘센트가 없습니다. 부족/보통/넉넉 중에 선택해주세요."),
-    NOISE_NOT_FOUND(HttpStatus.NOT_FOUND, "PLACE_005", "필터에 해당하는 소음이 없습니다. 조용함/보통/생기있음 중에 선택해주세요."),
-    INVALID_DAY(HttpStatus.BAD_REQUEST, "PLACE_006", "잘못된 요일 입니다."),
-    WIFI_NOT_FOUND(HttpStatus.NOT_FOUND, "PLACE_007", "필터에 해당하는 와이파이가 없습니다. 있어요/없어요 중에 선택해주세요."),
-    INVALID_TIME_FILTER(HttpStatus.BAD_REQUEST, "PLACE_008", "운영 시간 필터가 잘못되었습니다. 필터를 적용할 시간과 요일을 함께 보내주세요"),
-    BOOKMARK_FAILED(HttpStatus.BAD_REQUEST, "PLACE_009", "해당 공간 북마크 등록에 실패하였습니다."),
-    UNBOOKMARK_FAILED(HttpStatus.BAD_REQUEST, "PLACE_010", "해당 공간 북마크 해제에 실패하였습니다."),
-    USERPLACE_NOT_FOUND(HttpStatus.BAD_REQUEST, "PLACE_011", "해당 유저의 저장 공간이 존재하지 않습니다."),
-    PLACE_NOT_FOUND(HttpStatus.BAD_REQUEST, "PLACE_012", "해당 공간이 존재하지 않습니다."),
-    PLACE_CLOSED(HttpStatus.BAD_REQUEST, "PLACE_013", "해당 공간은 오늘 휴무일입니다."),
 
     ;
 

--- a/src/main/java/com/nurigil/nurigil/global/apiPayload/exception/handler/MemberHandler.java
+++ b/src/main/java/com/nurigil/nurigil/global/apiPayload/exception/handler/MemberHandler.java
@@ -1,0 +1,10 @@
+package com.nurigil.nurigil.global.apiPayload.exception.handler;
+
+import com.nurigil.nurigil.global.apiPayload.code.BaseErrorCode;
+import com.nurigil.nurigil.global.apiPayload.exception.GeneralException;
+
+public class MemberHandler extends GeneralException {
+    public MemberHandler(BaseErrorCode baseErrorCode) {
+        super(baseErrorCode);
+    }
+}

--- a/src/main/java/com/nurigil/nurigil/global/apiPayload/exception/handler/MemberPrefenceHandler.java
+++ b/src/main/java/com/nurigil/nurigil/global/apiPayload/exception/handler/MemberPrefenceHandler.java
@@ -1,0 +1,10 @@
+package com.nurigil.nurigil.global.apiPayload.exception.handler;
+
+import com.nurigil.nurigil.global.apiPayload.code.BaseErrorCode;
+import com.nurigil.nurigil.global.apiPayload.exception.GeneralException;
+
+public class MemberPrefenceHandler extends GeneralException {
+    public MemberPrefenceHandler(BaseErrorCode baseErrorCode) {
+        super(baseErrorCode);
+    }
+}

--- a/src/main/java/com/nurigil/nurigil/global/domain/common/BaseEntity.java
+++ b/src/main/java/com/nurigil/nurigil/global/domain/common/BaseEntity.java
@@ -21,7 +21,4 @@ public class BaseEntity {
     @LastModifiedDate
     @Column(name = "updated_at", nullable = false, columnDefinition = "TIMESTAMP")
     private LocalDateTime updatedAt;
-
-    @Column(name = "deleted_at", columnDefinition = "TIMESTAMP")
-    private LocalDateTime deletedAt;
 }

--- a/src/main/java/com/nurigil/nurigil/global/repository/MemberPreferenceRepository.java
+++ b/src/main/java/com/nurigil/nurigil/global/repository/MemberPreferenceRepository.java
@@ -1,0 +1,7 @@
+package com.nurigil.nurigil.global.repository;
+
+import com.nurigil.nurigil.global.domain.entity.MemberPreference;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberPreferenceRepository extends JpaRepository<MemberPreference, Long> {
+}

--- a/src/main/java/com/nurigil/nurigil/global/service/MemberPreferenceService/MemberPreferenceService.java
+++ b/src/main/java/com/nurigil/nurigil/global/service/MemberPreferenceService/MemberPreferenceService.java
@@ -1,0 +1,8 @@
+package com.nurigil.nurigil.global.service.MemberPreferenceService;
+
+import com.nurigil.nurigil.global.web.dto.MemberPreference.MemberPreferenceRequestDTO;
+import com.nurigil.nurigil.global.web.dto.MemberPreference.MemberPreferenceResponseDTO;
+
+public interface MemberPreferenceService {
+    MemberPreferenceResponseDTO.MemberPreferenceResponse createMemberPreference(Long memberId, MemberPreferenceRequestDTO.MemberPreferenceRequest request);
+}

--- a/src/main/java/com/nurigil/nurigil/global/service/MemberPreferenceService/MemberPreferenceServiceImpl.java
+++ b/src/main/java/com/nurigil/nurigil/global/service/MemberPreferenceService/MemberPreferenceServiceImpl.java
@@ -1,0 +1,47 @@
+package com.nurigil.nurigil.global.service.MemberPreferenceService;
+
+import com.nurigil.nurigil.global.apiPayload.code.status.ErrorStatus;
+import com.nurigil.nurigil.global.apiPayload.exception.handler.MemberHandler;
+import com.nurigil.nurigil.global.apiPayload.exception.handler.MemberPrefenceHandler;
+import com.nurigil.nurigil.global.domain.entity.Member;
+import com.nurigil.nurigil.global.domain.entity.MemberPreference;
+import com.nurigil.nurigil.global.repository.MemberPreferenceRepository;
+import com.nurigil.nurigil.global.repository.MemberRepository;
+import com.nurigil.nurigil.global.web.dto.MemberPreference.MemberPreferenceRequestDTO;
+import com.nurigil.nurigil.global.web.dto.MemberPreference.MemberPreferenceResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberPreferenceServiceImpl implements MemberPreferenceService{
+
+    private final MemberRepository memberRepository;
+    private final MemberPreferenceRepository memberPreferenceRepository;
+
+    // 선호 설정 등록 API
+    @Override
+    public MemberPreferenceResponseDTO.MemberPreferenceResponse createMemberPreference(Long memberId, MemberPreferenceRequestDTO.MemberPreferenceRequest request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_ID_NULL));
+
+        // 이미 선호 설정이 있는 경우 덮어쓰기 방지 or 예외 처리
+        if (member.getMemberPreference() != null) {
+            throw new MemberPrefenceHandler(ErrorStatus.MEMBER_PREFERENCE_ALREADY_EXISTS);
+        }
+
+        MemberPreference memberPreference = MemberPreference.builder()
+                .member(member)
+                .difficulty(request.getDifficulty())
+                .slope(request.getSlope())
+                .build();
+
+        memberPreferenceRepository.save(memberPreference);
+
+        return MemberPreferenceResponseDTO.MemberPreferenceResponse.builder()
+                .difficulty(memberPreference.getDifficulty())
+                .slope(memberPreference.getSlope())
+                .build();
+    }
+}

--- a/src/main/java/com/nurigil/nurigil/global/web/controller/MemberPreferenceController.java
+++ b/src/main/java/com/nurigil/nurigil/global/web/controller/MemberPreferenceController.java
@@ -2,7 +2,12 @@ package com.nurigil.nurigil.global.web.controller;
 
 import com.nurigil.nurigil.global.apiPayload.ApiResponse;
 import com.nurigil.nurigil.global.apiPayload.code.status.SuccessStatus;
+import com.nurigil.nurigil.global.service.MemberPreferenceService.MemberPreferenceService;
+import com.nurigil.nurigil.global.web.dto.MemberPreference.MemberPreferenceRequestDTO;
+import com.nurigil.nurigil.global.web.dto.MemberPreference.MemberPreferenceResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,11 +23,19 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "멤버 선호 API", description = "멤버 선호 API입니다.")
 public class MemberPreferenceController {
 
+    private final MemberPreferenceService memberPreferenceService;
+
     // 선호 설정 등록 API
     @Operation(summary = "선호 설정 등록 API", description = "선호 설정 등록 API 입니다.")
-    @PostMapping(   "/{id}")
-    public ApiResponse<?> PostMemberPreference() {
-        return ApiResponse.onSuccess(SuccessStatus.MEMBER_PREFERENCE_POST_OK, null);
+    @Parameters({
+            @Parameter(name = "member_id", description = "멤버 ID, 차후 hidden으로 수정 예정", required = true)
+    })
+    @PostMapping(   "/{member_id}")
+    public ApiResponse<MemberPreferenceResponseDTO.MemberPreferenceResponse> CreateMemberPreference(
+            @PathVariable("member_id") Long memberId,
+            @RequestBody MemberPreferenceRequestDTO.MemberPreferenceRequest request) {
+        MemberPreferenceResponseDTO.MemberPreferenceResponse response = memberPreferenceService.createMemberPreference(memberId, request);
+        return ApiResponse.onSuccess(SuccessStatus.MEMBER_PREFERENCE_POST_OK, response);
     }
 
     // 선호 설정 조회 API

--- a/src/main/java/com/nurigil/nurigil/global/web/dto/MemberPreference/MemberPreferenceRequestDTO.java
+++ b/src/main/java/com/nurigil/nurigil/global/web/dto/MemberPreference/MemberPreferenceRequestDTO.java
@@ -1,0 +1,17 @@
+package com.nurigil.nurigil.global.web.dto.MemberPreference;
+
+import com.nurigil.nurigil.global.domain.enums.Difficulty;
+import com.nurigil.nurigil.global.domain.enums.Slope;
+import lombok.*;
+
+public class MemberPreferenceRequestDTO {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class MemberPreferenceRequest {
+        private Difficulty difficulty;
+        private Slope slope;
+    }
+}

--- a/src/main/java/com/nurigil/nurigil/global/web/dto/MemberPreference/MemberPreferenceResponseDTO.java
+++ b/src/main/java/com/nurigil/nurigil/global/web/dto/MemberPreference/MemberPreferenceResponseDTO.java
@@ -1,0 +1,17 @@
+package com.nurigil.nurigil.global.web.dto.MemberPreference;
+
+import com.nurigil.nurigil.global.domain.enums.Difficulty;
+import com.nurigil.nurigil.global.domain.enums.Slope;
+import lombok.*;
+
+public class MemberPreferenceResponseDTO {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class MemberPreferenceResponse {
+        private Difficulty difficulty;
+        private Slope slope;
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #14 

## 📝작업 내용
> 선호 설정 등록 API 구현

## 🔎코드 설명 및 참고 사항
> Swagger 확인
request
<img width="398" alt="image" src="https://github.com/user-attachments/assets/0a6e8752-7979-4757-857c-6443c11b45a7" />

response
<img width="278" alt="image" src="https://github.com/user-attachments/assets/110825c1-1b3c-4740-accf-5b7a66ffaaeb" />

파라미터로 memerId를 받는데 로그인 구현되면 차후 hidden으로 파라미터 안보이게 할 예정입니다


## 💬리뷰 요구사항
>
