### PR TITLE
Feat: 선호 등록 조회 api

### DIFF
--- a/src/main/java/com/nurigil/nurigil/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/nurigil/nurigil/global/apiPayload/code/status/ErrorStatus.java
@@ -48,6 +48,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // MemberPreference 관련
     MEMBER_PREFERENCE_ALREADY_EXISTS(HttpStatus.CONFLICT, "MEMBERPREFERENCE_4091", "이미 선호 설정이 존재합니다."),
+    MEMBER_PREFERENCE_NULL(HttpStatus.NOT_FOUND, "MEMBERPREFERENCE_4041", "선호 설정이 존재하지 않습니다."),
 
     //Search 관련
     SEARCH_CONDITION_INVALID(HttpStatus.BAD_REQUEST, "SEARCH_001", "검색 조건이 하나라도 존재해야 합니다."),

--- a/src/main/java/com/nurigil/nurigil/global/converter/MemberPreferenceConverter.java
+++ b/src/main/java/com/nurigil/nurigil/global/converter/MemberPreferenceConverter.java
@@ -1,0 +1,23 @@
+package com.nurigil.nurigil.global.converter;
+
+import com.nurigil.nurigil.global.domain.entity.MemberPreference;
+import com.nurigil.nurigil.global.web.dto.MemberPreference.MemberPreferenceRequestDTO;
+import com.nurigil.nurigil.global.web.dto.MemberPreference.MemberPreferenceResponseDTO;
+
+public class MemberPreferenceConverter {
+
+    public static MemberPreference toMemberPreference(MemberPreferenceRequestDTO.Request request) {
+        return MemberPreference.builder()
+                .difficulty(request.getDifficulty())
+                .slope(request.getSlope())
+                .build();
+    }
+
+    // 선호 내용을 갖는 DTO로 변경
+    public static MemberPreferenceResponseDTO.Response toCreateResultDTO(MemberPreference memberPreference) {
+        return MemberPreferenceResponseDTO.Response.builder()
+                .difficulty(memberPreference.getDifficulty())
+                .slope(memberPreference.getSlope())
+                .build();
+    }
+}

--- a/src/main/java/com/nurigil/nurigil/global/repository/MemberPreferenceRepository.java
+++ b/src/main/java/com/nurigil/nurigil/global/repository/MemberPreferenceRepository.java
@@ -1,7 +1,11 @@
 package com.nurigil.nurigil.global.repository;
 
+import com.nurigil.nurigil.global.domain.entity.Member;
 import com.nurigil.nurigil.global.domain.entity.MemberPreference;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberPreferenceRepository extends JpaRepository<MemberPreference, Long> {
+    Optional<MemberPreference> findByMember(Member member);
 }

--- a/src/main/java/com/nurigil/nurigil/global/service/MemberPreferenceService/MemberPreferenceService.java
+++ b/src/main/java/com/nurigil/nurigil/global/service/MemberPreferenceService/MemberPreferenceService.java
@@ -5,4 +5,5 @@ import com.nurigil.nurigil.global.web.dto.MemberPreference.MemberPreferenceRespo
 
 public interface MemberPreferenceService {
     MemberPreferenceResponseDTO.Response createMemberPreference(Long memberId, MemberPreferenceRequestDTO.Request request);
+    MemberPreferenceResponseDTO.Response getMemberPreference(Long memberId);
 }

--- a/src/main/java/com/nurigil/nurigil/global/service/MemberPreferenceService/MemberPreferenceService.java
+++ b/src/main/java/com/nurigil/nurigil/global/service/MemberPreferenceService/MemberPreferenceService.java
@@ -4,5 +4,5 @@ import com.nurigil.nurigil.global.web.dto.MemberPreference.MemberPreferenceReque
 import com.nurigil.nurigil.global.web.dto.MemberPreference.MemberPreferenceResponseDTO;
 
 public interface MemberPreferenceService {
-    MemberPreferenceResponseDTO.MemberPreferenceResponse createMemberPreference(Long memberId, MemberPreferenceRequestDTO.MemberPreferenceRequest request);
+    MemberPreferenceResponseDTO.Response createMemberPreference(Long memberId, MemberPreferenceRequestDTO.Request request);
 }

--- a/src/main/java/com/nurigil/nurigil/global/service/MemberPreferenceService/MemberPreferenceServiceImpl.java
+++ b/src/main/java/com/nurigil/nurigil/global/service/MemberPreferenceService/MemberPreferenceServiceImpl.java
@@ -3,6 +3,7 @@ package com.nurigil.nurigil.global.service.MemberPreferenceService;
 import com.nurigil.nurigil.global.apiPayload.code.status.ErrorStatus;
 import com.nurigil.nurigil.global.apiPayload.exception.handler.MemberHandler;
 import com.nurigil.nurigil.global.apiPayload.exception.handler.MemberPrefenceHandler;
+import com.nurigil.nurigil.global.converter.MemberPreferenceConverter;
 import com.nurigil.nurigil.global.domain.entity.Member;
 import com.nurigil.nurigil.global.domain.entity.MemberPreference;
 import com.nurigil.nurigil.global.repository.MemberPreferenceRepository;
@@ -22,7 +23,7 @@ public class MemberPreferenceServiceImpl implements MemberPreferenceService{
 
     // 선호 설정 등록 API
     @Override
-    public MemberPreferenceResponseDTO.MemberPreferenceResponse createMemberPreference(Long memberId, MemberPreferenceRequestDTO.MemberPreferenceRequest request) {
+    public MemberPreferenceResponseDTO.Response createMemberPreference(Long memberId, MemberPreferenceRequestDTO.Request request) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_ID_NULL));
 
@@ -31,17 +32,14 @@ public class MemberPreferenceServiceImpl implements MemberPreferenceService{
             throw new MemberPrefenceHandler(ErrorStatus.MEMBER_PREFERENCE_ALREADY_EXISTS);
         }
 
-        MemberPreference memberPreference = MemberPreference.builder()
-                .member(member)
-                .difficulty(request.getDifficulty())
-                .slope(request.getSlope())
-                .build();
+        MemberPreference newMemberPreference = MemberPreferenceConverter.toMemberPreference(request);
+        newMemberPreference.setMember(member);
 
-        memberPreferenceRepository.save(memberPreference);
+        memberPreferenceRepository.save(newMemberPreference);
 
-        return MemberPreferenceResponseDTO.MemberPreferenceResponse.builder()
-                .difficulty(memberPreference.getDifficulty())
-                .slope(memberPreference.getSlope())
-                .build();
+        return MemberPreferenceConverter.toCreateResultDTO(newMemberPreference);
     }
+
+    // 선호 설정 조회 API
+
 }

--- a/src/main/java/com/nurigil/nurigil/global/service/MemberPreferenceService/MemberPreferenceServiceImpl.java
+++ b/src/main/java/com/nurigil/nurigil/global/service/MemberPreferenceService/MemberPreferenceServiceImpl.java
@@ -14,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class MemberPreferenceServiceImpl implements MemberPreferenceService{
@@ -41,5 +43,19 @@ public class MemberPreferenceServiceImpl implements MemberPreferenceService{
     }
 
     // 선호 설정 조회 API
+    @Override
+    public MemberPreferenceResponseDTO.Response getMemberPreference(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_ID_NULL));
+
+        MemberPreference memberPreference = memberPreferenceRepository
+                .findByMember(member)
+                .orElseThrow(() -> new MemberPrefenceHandler(ErrorStatus.MEMBER_PREFERENCE_NULL));
+
+        return MemberPreferenceConverter.toCreateResultDTO(memberPreference);
+    }
+
+
+
 
 }

--- a/src/main/java/com/nurigil/nurigil/global/web/controller/MemberPreferenceController.java
+++ b/src/main/java/com/nurigil/nurigil/global/web/controller/MemberPreferenceController.java
@@ -44,8 +44,11 @@ public class MemberPreferenceController {
             @Parameter(name = "memberId", description = "멤버 ID, 차후 hidden으로 수정 예정", required = false)
     })
     @GetMapping("/{memberId}")
-    public ApiResponse<?> GetMemberPreference() {
-        return ApiResponse.onSuccess(SuccessStatus.MEMBER_PREFERENCE_GET_OK, null);
+    public ApiResponse<MemberPreferenceResponseDTO.Response> GetMemberPreference(
+            @PathVariable("memberId") Long memberId
+    ) {
+        MemberPreferenceResponseDTO.Response response = memberPreferenceService.getMemberPreference(memberId);
+        return ApiResponse.onSuccess(SuccessStatus.MEMBER_PREFERENCE_GET_OK, response);
     }
 
     // 선호 설정 수정 API

--- a/src/main/java/com/nurigil/nurigil/global/web/controller/MemberPreferenceController.java
+++ b/src/main/java/com/nurigil/nurigil/global/web/controller/MemberPreferenceController.java
@@ -28,19 +28,22 @@ public class MemberPreferenceController {
     // 선호 설정 등록 API
     @Operation(summary = "선호 설정 등록 API", description = "선호 설정 등록 API 입니다.")
     @Parameters({
-            @Parameter(name = "member_id", description = "멤버 ID, 차후 hidden으로 수정 예정", required = true)
+            @Parameter(name = "memberId", description = "멤버 ID, 차후 hidden으로 수정 예정", required = false)
     })
-    @PostMapping(   "/{member_id}")
-    public ApiResponse<MemberPreferenceResponseDTO.MemberPreferenceResponse> CreateMemberPreference(
-            @PathVariable("member_id") Long memberId,
-            @RequestBody MemberPreferenceRequestDTO.MemberPreferenceRequest request) {
-        MemberPreferenceResponseDTO.MemberPreferenceResponse response = memberPreferenceService.createMemberPreference(memberId, request);
+    @PostMapping("/{memberId}")
+    public ApiResponse<MemberPreferenceResponseDTO.Response> CreateMemberPreference(
+            @PathVariable("memberId") Long memberId,
+            @RequestBody MemberPreferenceRequestDTO.Request request) {
+        MemberPreferenceResponseDTO.Response response = memberPreferenceService.createMemberPreference(memberId, request);
         return ApiResponse.onSuccess(SuccessStatus.MEMBER_PREFERENCE_POST_OK, response);
     }
 
     // 선호 설정 조회 API
     @Operation(summary = "선호 설정 조회 API", description = "선호 설정 조회 API 입니다.")
-    @GetMapping(   "/{id}")
+    @Parameters({
+            @Parameter(name = "memberId", description = "멤버 ID, 차후 hidden으로 수정 예정", required = false)
+    })
+    @GetMapping("/{memberId}")
     public ApiResponse<?> GetMemberPreference() {
         return ApiResponse.onSuccess(SuccessStatus.MEMBER_PREFERENCE_GET_OK, null);
     }

--- a/src/main/java/com/nurigil/nurigil/global/web/dto/MemberPreference/MemberPreferenceRequestDTO.java
+++ b/src/main/java/com/nurigil/nurigil/global/web/dto/MemberPreference/MemberPreferenceRequestDTO.java
@@ -10,7 +10,7 @@ public class MemberPreferenceRequestDTO {
     @Builder
     @AllArgsConstructor(access = AccessLevel.PROTECTED)
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    public static class MemberPreferenceRequest {
+    public static class Request {
         private Difficulty difficulty;
         private Slope slope;
     }

--- a/src/main/java/com/nurigil/nurigil/global/web/dto/MemberPreference/MemberPreferenceResponseDTO.java
+++ b/src/main/java/com/nurigil/nurigil/global/web/dto/MemberPreference/MemberPreferenceResponseDTO.java
@@ -10,7 +10,7 @@ public class MemberPreferenceResponseDTO {
     @Builder
     @AllArgsConstructor(access = AccessLevel.PROTECTED)
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    public static class MemberPreferenceResponse {
+    public static class Response {
         private Difficulty difficulty;
         private Slope slope;
     }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #16 

## 📝작업 내용
> 선호 내용을 조회하는 API 입니다.

## 🔎코드 설명 및 참고 사항
> 성공 시 응답
<img width="286" alt="image" src="https://github.com/user-attachments/assets/ecf8c9fb-e4ce-4f7e-abb0-27911e2492bd" />

> 실패 시 응답 (memebrId가 유효하지 않을 때)
<img width="287" alt="image" src="https://github.com/user-attachments/assets/2eec8d6b-6bec-473d-b4d8-d8f5a220e0cc" />

## 💬리뷰 요구사항
>
