### PR TITLE
Feat: 산책 달력 데이터 전체 조회 API

### DIFF
--- a/src/main/java/com/nurigil/nurigil/global/converter/WalkCalendarConverter.java
+++ b/src/main/java/com/nurigil/nurigil/global/converter/WalkCalendarConverter.java
@@ -1,0 +1,26 @@
+package com.nurigil.nurigil.global.converter;
+
+import com.nurigil.nurigil.global.domain.entity.WalkCalendar;
+import com.nurigil.nurigil.global.web.dto.WalkCalendar.WalkCalendarResponseDTO;
+
+import java.util.List;
+
+public class WalkCalendarConverter {
+
+    // 산책 날짜를 변환하는 DTO
+    public static WalkCalendarResponseDTO.DetailResponse toDetailWalkCalendar(WalkCalendar walkCalendar) {
+        return WalkCalendarResponseDTO.DetailResponse.builder()
+                .date(walkCalendar.getDate())
+                .calories(walkCalendar.getCalories())
+                .totalDistance(walkCalendar.getTotalDistance())
+                .totalTime(walkCalendar.getTotalTime())
+                .build();
+    }
+
+    // 모든 산책 날짜를 변환하는 DTO
+    public static WalkCalendarResponseDTO.AllResponse toAllWalkCalendar(List<WalkCalendar> walkCalendars) {
+        return WalkCalendarResponseDTO.AllResponse.builder()
+                .responses(walkCalendars.stream().map(WalkCalendarConverter::toDetailWalkCalendar).toList())
+                .build();
+    }
+}

--- a/src/main/java/com/nurigil/nurigil/global/domain/entity/WalkCalendar.java
+++ b/src/main/java/com/nurigil/nurigil/global/domain/entity/WalkCalendar.java
@@ -8,7 +8,6 @@ import java.time.LocalDate;
 
 @Entity
 @Getter
-@Setter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/com/nurigil/nurigil/global/repository/WalkCalendarRepository.java
+++ b/src/main/java/com/nurigil/nurigil/global/repository/WalkCalendarRepository.java
@@ -1,0 +1,11 @@
+package com.nurigil.nurigil.global.repository;
+
+import com.nurigil.nurigil.global.domain.entity.Member;
+import com.nurigil.nurigil.global.domain.entity.WalkCalendar;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface WalkCalendarRepository extends JpaRepository<WalkCalendar, Long> {
+    List<WalkCalendar> findAllByMember(Member member);
+}

--- a/src/main/java/com/nurigil/nurigil/global/service/WalkCalendarService/WalkCalendarService.java
+++ b/src/main/java/com/nurigil/nurigil/global/service/WalkCalendarService/WalkCalendarService.java
@@ -1,0 +1,7 @@
+package com.nurigil.nurigil.global.service.WalkCalendarService;
+
+import com.nurigil.nurigil.global.web.dto.WalkCalendar.WalkCalendarResponseDTO;
+
+public interface WalkCalendarService {
+    WalkCalendarResponseDTO.AllResponse getWalkCalendar(Long memberId);
+}

--- a/src/main/java/com/nurigil/nurigil/global/service/WalkCalendarService/WalkCalendarServiceImpl.java
+++ b/src/main/java/com/nurigil/nurigil/global/service/WalkCalendarService/WalkCalendarServiceImpl.java
@@ -1,0 +1,32 @@
+package com.nurigil.nurigil.global.service.WalkCalendarService;
+
+import com.nurigil.nurigil.global.apiPayload.code.status.ErrorStatus;
+import com.nurigil.nurigil.global.apiPayload.exception.handler.MemberHandler;
+import com.nurigil.nurigil.global.converter.WalkCalendarConverter;
+import com.nurigil.nurigil.global.domain.entity.Member;
+import com.nurigil.nurigil.global.domain.entity.WalkCalendar;
+import com.nurigil.nurigil.global.repository.MemberRepository;
+import com.nurigil.nurigil.global.repository.WalkCalendarRepository;
+import com.nurigil.nurigil.global.web.dto.WalkCalendar.WalkCalendarResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class WalkCalendarServiceImpl implements WalkCalendarService{
+
+    private final MemberRepository memberRepository;
+    private final WalkCalendarRepository walkCalendarRepository;
+
+    @Override
+    public WalkCalendarResponseDTO.AllResponse getWalkCalendar(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_ID_NULL));
+
+        List<WalkCalendar> calendarList = walkCalendarRepository.findAllByMember(member);
+
+        return WalkCalendarConverter.toAllWalkCalendar(calendarList);
+    }
+}

--- a/src/main/java/com/nurigil/nurigil/global/web/controller/WalkCalendarController.java
+++ b/src/main/java/com/nurigil/nurigil/global/web/controller/WalkCalendarController.java
@@ -2,7 +2,11 @@ package com.nurigil.nurigil.global.web.controller;
 
 import com.nurigil.nurigil.global.apiPayload.ApiResponse;
 import com.nurigil.nurigil.global.apiPayload.code.status.SuccessStatus;
+import com.nurigil.nurigil.global.service.WalkCalendarService.WalkCalendarService;
+import com.nurigil.nurigil.global.web.dto.WalkCalendar.WalkCalendarResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,14 +19,22 @@ import org.springframework.web.bind.annotation.*;
 @CrossOrigin
 @Slf4j
 @RequestMapping("/members/calendar")
-@Tag(name = "코스 신고 API", description = "코스 신고 API입니다.")
+@Tag(name = "산책 달력 API", description = "산책 달력 API입니다.")
 public class WalkCalendarController {
+
+    private final WalkCalendarService walkCalendarService;
 
     // 산책 달력 데이터 전체 조회 API
     @Operation(summary = "산책 달력 데이터 전체 조회 API", description = "산책 달력 데이터 전체 조회 API 입니다.")
-    @GetMapping(   "/{member_id}")
-    public ApiResponse<?> GetCalendars() {
-        return ApiResponse.onSuccess(SuccessStatus.WALK_CALENDAR_OK, null);
+    @Parameters({
+            @Parameter(name = "memberId", description = "멤버 ID, 추후 hidden으로 수정 예정")
+    })
+    @GetMapping("/{memberId}")
+    public ApiResponse<WalkCalendarResponseDTO.AllResponse> GetCalendars(
+            @PathVariable("memberId") Long memberId
+    ) {
+        WalkCalendarResponseDTO.AllResponse response = walkCalendarService.getWalkCalendar(memberId);
+        return ApiResponse.onSuccess(SuccessStatus.WALK_CALENDAR_OK, response);
     }
 
     // 특정 날짜 산책 기록 조회 API

--- a/src/main/java/com/nurigil/nurigil/global/web/dto/WalkCalendar/WalkCalendarResponseDTO.java
+++ b/src/main/java/com/nurigil/nurigil/global/web/dto/WalkCalendar/WalkCalendarResponseDTO.java
@@ -1,0 +1,30 @@
+package com.nurigil.nurigil.global.web.dto.WalkCalendar;
+
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class WalkCalendarResponseDTO {
+
+    // 모든 날짜의 산책 기록
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @RequiredArgsConstructor
+    public static class AllResponse {
+        private List<DetailResponse> responses;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @RequiredArgsConstructor
+    // 특정 날짜의 산책 기록
+    public static class DetailResponse {
+        private LocalDate date;
+        private Float totalDistance;
+        private Integer totalTime;
+        private Float calories;
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #20 

## 📝작업 내용
> 산책 달력 데이터 전체 조회 API

## 🔎코드 설명 및 참고 사항
> 실행 결과
<img width="376" alt="image" src="https://github.com/user-attachments/assets/e94df103-628d-4dfc-885d-dee6f14c69cd" />

산책 달력 데이터 결과를 List로 반환하게 했습니다. 페이징은 적용 안 시켰는데, 달력을 어떤 식으로 넘기는지 확인이 안돼서 나중에 프론트 분한테 물어보고 수정하겠습니다.

## 💬리뷰 요구사항
>
